### PR TITLE
Fix drift query and index definitions

### DIFF
--- a/lib/data/db/tables.dart
+++ b/lib/data/db/tables.dart
@@ -43,7 +43,10 @@ class CategoriesTable extends Table {
 
   @override
   List<Index> get indexes => [
-        Index('idx_categories_kind_sort', columns: [kind, sort]),
+        Index(
+          'idx_categories_kind_sort',
+          'CREATE INDEX IF NOT EXISTS idx_categories_kind_sort ON categories (kind, sort)',
+        ),
       ];
 }
 
@@ -88,7 +91,12 @@ class PlanItemsTable extends Table {
   Set<Column> get primaryKey => {id};
 
   @override
-  List<Index> get indexes => [Index('idx_plan_period', columns: [periodId])];
+  List<Index> get indexes => [
+        Index(
+          'idx_plan_period',
+          'CREATE INDEX IF NOT EXISTS idx_plan_period ON plan_items (period_id)',
+        ),
+      ];
 }
 
 class CriticalityTable extends Table {
@@ -109,7 +117,10 @@ class CriticalityTable extends Table {
 
   @override
   List<Index> get indexes => [
-        Index('idx_criticality_sort', columns: [sort, archived]),
+        Index(
+          'idx_criticality_sort',
+          'CREATE INDEX IF NOT EXISTS idx_criticality_sort ON criticality (sort, archived)',
+        ),
       ];
 }
 
@@ -142,10 +153,22 @@ class TransactionsTable extends Table {
 
   @override
   List<Index> get indexes => [
-        Index('idx_tx_datetime_account', columns: [datetime, accountId]),
-        Index('idx_tx_category_datetime', columns: [categoryId, datetime]),
-        Index('idx_tx_plan', columns: [planItemId]),
-        Index('idx_tx_criticality', columns: [criticalityId]),
+        Index(
+          'idx_tx_datetime_account',
+          'CREATE INDEX IF NOT EXISTS idx_tx_datetime_account ON transactions (datetime, account_id)',
+        ),
+        Index(
+          'idx_tx_category_datetime',
+          'CREATE INDEX IF NOT EXISTS idx_tx_category_datetime ON transactions (category_id, datetime)',
+        ),
+        Index(
+          'idx_tx_plan',
+          'CREATE INDEX IF NOT EXISTS idx_tx_plan ON transactions (plan_item_id)',
+        ),
+        Index(
+          'idx_tx_criticality',
+          'CREATE INDEX IF NOT EXISTS idx_tx_criticality ON transactions (criticality_id)',
+        ),
       ];
 }
 

--- a/lib/data/repositories/transactions_repository.dart
+++ b/lib/data/repositories/transactions_repository.dart
@@ -245,14 +245,14 @@ class TransactionsRepository {
     final query = _db.selectOnly(tx)
       ..addColumns([sumExpr])
       ..where(
-        (tbl) => tbl.datetime.isBetweenValues(period.startDate, period.endDate),
+        tx.datetime.isBetweenValues(period.startDate, period.endDate),
       )
-      ..where((tbl) => tbl.type.equals(type));
+      ..where(tx.type.equals(type));
     if (excludeFromBudget != null) {
-      query.where((tbl) => tbl.excludeFromBudget.equals(excludeFromBudget));
+      query.where(tx.excludeFromBudget.equals(excludeFromBudget));
     }
     if (planOnly) {
-      query.where((tbl) => tbl.planItemId.isNotNull());
+      query.where(tx.planItemId.isNotNull());
     }
     final result = await query.getSingleOrNull();
     final sum = result?.read(sumExpr) ?? 0;
@@ -265,10 +265,10 @@ class TransactionsRepository {
     final query = _db.selectOnly(tx)
       ..addColumns([sumExpr])
       ..where(
-        (tbl) => tbl.datetime.isBetweenValues(period.startDate, period.endDate),
+        tx.datetime.isBetweenValues(period.startDate, period.endDate),
       )
-      ..where((tbl) => tbl.type.equals('expense'))
-      ..where((tbl) => tbl.planItemId.isNull());
+      ..where(tx.type.equals('expense'))
+      ..where(tx.planItemId.isNull());
     final result = await query.getSingleOrNull();
     return result?.read(sumExpr) ?? 0;
   }
@@ -281,10 +281,10 @@ class TransactionsRepository {
     final query = _db.selectOnly(tx)
       ..addColumns([critColumn, sumExpr])
       ..where(
-        (tbl) => tbl.datetime.isBetweenValues(period.startDate, period.endDate),
+        tx.datetime.isBetweenValues(period.startDate, period.endDate),
       )
-      ..where((tbl) => tbl.type.equals('expense'))
-      ..where((tbl) => tbl.excludeFromBudget.equals(false))
+      ..where(tx.type.equals('expense'))
+      ..where(tx.excludeFromBudget.equals(false))
       ..groupBy([tx.criticalityId]);
     final rows = await query.get();
     final result = <String, int>{};
@@ -300,7 +300,7 @@ class TransactionsRepository {
   Future<List<String>> lastCriticalityIds(int limit) async {
     final tx = _db.transactionsTable;
     final query = _db.select(tx)
-      ..where((tbl) => tbl.criticalityId.isNotNull())
+      ..where(tx.criticalityId.isNotNull())
       ..orderBy([(tbl) => OrderingTerm(expression: tbl.datetime, mode: OrderingMode.desc)])
       ..limit(limit * 2);
     final rows = await query.get();


### PR DESCRIPTION
## Summary
- update repository queries to use the new drift `where` API
- rewrite table index definitions to the new constructor signature

## Testing
- not run (environment does not include Flutter/Dart tooling)


------
https://chatgpt.com/codex/tasks/task_e_68ce5d2cabdc8326847737313f7bdc19